### PR TITLE
Fixed file naming conventions

### DIFF
--- a/buildtools/theme-configurator.js
+++ b/buildtools/theme-configurator.js
@@ -113,8 +113,8 @@ var handler = function (compileStep, isLiterate) {
   var variablesLessFile = jsonPath.replace(/json$/i, 'variables.import.less')
 
   // User editable files
-  var userImportsLessFile = jsonPath.replace(/json$/i, 'user-imports.less');
-  var userOverridesLessFile = jsonPath.replace(/json$/i, 'user-overrides.less');
+  var userImportsLessFile = jsonPath.replace(/json$/i, 'import.less');
+  var userOverridesLessFile = jsonPath.replace(/json$/i, 'overrides.import.less');
 
   // Final output
   var outputLessFile = jsonPath.replace(/json$/i, 'less');


### PR DESCRIPTION
Following meteor less file naming conventions for imported less files. This should resolve load order issues for imported user editable less files.

Fixes reactioncommerce/reaction#341